### PR TITLE
RFC: Agreguar trackId al output de la simulación

### DIFF
--- a/src/main/avro/schemas.avsc
+++ b/src/main/avro/schemas.avsc
@@ -133,6 +133,10 @@
         "type": "record",
         "name": "song",
         "fields": [
+          { 
+            "name": "trackId",
+            "type": "string"
+          },
           {
             "name": "artist",
             "type": "string"

--- a/src/main/scala/io/confluent/eventsim/Output.scala
+++ b/src/main/scala/io/confluent/eventsim/Output.scala
@@ -126,6 +126,7 @@ object Output {
       pageViewConstructor.setTitle(session.currentSong.get._3)
       pageViewConstructor.setDuration(session.currentSong.get._4)
       listenConstructor.start()
+      listenConstructor.setTrackId(session.currentSong.get._1)
       listenConstructor.setArtist(session.currentSong.get._2)
       listenConstructor.setTitle(session.currentSong.get._3)
       listenConstructor.setDuration(session.currentSong.get._4)

--- a/src/main/scala/io/confluent/eventsim/Output.scala
+++ b/src/main/scala/io/confluent/eventsim/Output.scala
@@ -121,6 +121,7 @@ object Output {
     }
 
     if (session.currentState.page == "NextSong") {
+      pageViewConstructor.setTrackId(session.currentSong.get._1)
       pageViewConstructor.setArtist(session.currentSong.get._2)
       pageViewConstructor.setTitle(session.currentSong.get._3)
       pageViewConstructor.setDuration(session.currentSong.get._4)

--- a/src/main/scala/io/confluent/eventsim/events/Listen/AvroConstructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/Listen/AvroConstructor.scala
@@ -33,6 +33,8 @@ class AvroConstructor() extends io.confluent.eventsim.events.AvroConstructor[Lis
 
   def setAuth(s: String) = eventBuilder.setAuth(s)
 
+  def setTrackId(s: String) = songBuilder.setTrackId(s)
+
   def setArtist(s: String) = songBuilder.setArtist(s)
 
   def setTitle(s: String) = songBuilder.setTitle(s)

--- a/src/main/scala/io/confluent/eventsim/events/Listen/Constructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/Listen/Constructor.scala
@@ -3,6 +3,8 @@ package io.confluent.eventsim.events.Listen
 trait Constructor extends io.confluent.eventsim.events.Constructor {
   def setAuth(s: String)
 
+  def setTrackId(s: String)
+
   def setArtist(s: String)
 
   def setTitle(s: String)

--- a/src/main/scala/io/confluent/eventsim/events/Listen/JSONConstructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/Listen/JSONConstructor.scala
@@ -3,6 +3,8 @@ package io.confluent.eventsim.events.Listen
 class JSONConstructor() extends io.confluent.eventsim.events.JSONConstructor with Constructor {
   def setAuth(s: String) = generator.writeStringField("auth", s)
 
+  def setTrackId(s: String) = generator.writeStringField("trackId", s)
+
   def setArtist(s: String) = generator.writeStringField("artist", s)
 
   def setTitle(s: String) = generator.writeStringField("song", s)

--- a/src/main/scala/io/confluent/eventsim/events/PageView/AvroConstructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/PageView/AvroConstructor.scala
@@ -38,7 +38,9 @@ class AvroConstructor() extends io.confluent.eventsim.events.AvroConstructor[Pag
   def setMethod(s: String) = eventBuilder.setMethod(s)
 
   def setStatus(i: Int) = eventBuilder.setStatus(i)
-
+  
+  def setTrackId(s: String) = songBuilder.setTrackId(s)
+  
   def setArtist(s: String) = songBuilder.setArtist(s)
 
   def setTitle(s: String) = songBuilder.setTitle(s)

--- a/src/main/scala/io/confluent/eventsim/events/PageView/Constructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/PageView/Constructor.scala
@@ -9,6 +9,8 @@ trait Constructor extends io.confluent.eventsim.events.Constructor {
 
   def setStatus(i: Int)
 
+  def setTrackId(s: String)
+
   def setArtist(s: String)
 
   def setTitle(s: String)

--- a/src/main/scala/io/confluent/eventsim/events/PageView/JSONConstructor.scala
+++ b/src/main/scala/io/confluent/eventsim/events/PageView/JSONConstructor.scala
@@ -9,6 +9,8 @@ class JSONConstructor() extends io.confluent.eventsim.events.JSONConstructor wit
 
   def setStatus(i: Int) = generator.writeNumberField("status", i)
 
+  def setTrackId(s: String) = generator.writeStringField("trackId", s)
+  
   def setArtist(s: String) = generator.writeStringField("artist", s)
 
   def setTitle(s: String) = generator.writeStringField("song", s)


### PR DESCRIPTION
Agregué la propiedad trackId a los outputs de la simulación.

Ahora un pageview se ve así:

```
{"ts":1704548537817,"sessionId":1693,"page":"NextSong","auth":"Logged In","method":"PUT","status":200,"level":"paid","itemInSession":2,"city":"Tucson","zip":"85710","state":"AZ","userAgent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.94 Safari/537.36\"","lon":-110.823718,"lat":32.214133,"userId":472,"lastName":"Reyes","firstName":"Tyrique","gender":"M","registration":1704548482817,"trackId":"TRJHAGN128E078506F","artist":"Skillet","song":"A Little More (Album Version)","duration":289.6714}
```

y un evento de listen así:

```
{"trackId":"TRJHAGN128E078506F","artist":"Skillet","song":"A Little More (Album Version)","duration":289.6714,"ts":1704548537817,"sessionId":1693,"auth":"Logged In","level":"paid","itemInSession":2,"city":"Tucson","zip":"85710","state":"AZ","userAgent":"\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.94 Safari/537.36\"","lon":-110.823718,"lat":32.214133,"userId":472,"lastName":"Reyes","firstName":"Tyrique","gender":"M","registration":1704548482817}
```